### PR TITLE
Update schema with new column 'support' in cluster_thanos_info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ python:
   - "3.8"
   - "3.8-dev"  # 3.8 development branch
   - "nightly"  # nightly build
-
+addons:
+  apt:
+    packages:
+    - libsnappy-dev
 # Pycodestyle part
 # needed to work correctly with Python 3 shebang
 env: SKIP_INTERPRETER=true

--- a/docs/internal-pipeline/parquet_output.md
+++ b/docs/internal-pipeline/parquet_output.md
@@ -171,6 +171,7 @@ archives/compressed/0a/0aaaaaaa-bbbb-cccc-dddd-ffffffffffff/202102/08/003201.tar
 * `ebs_account` (byte array) account number
 * `email_domain` (byte array) an e-mail domain
 * `managed` (bool) flag whether the cluster is managed or not
+* `support` (byte array) specifies the support level of a cluster
 * `collected_at` (timestamp) timestamp of report represented with millisecond precision
 
 
@@ -201,6 +202,10 @@ An e-mail domain, for example: "redhat.com"
 #### `managed` (bool) attribute
 
 Boolean flag containing info if the cluster is managed or not.
+
+#### `support` attribute
+
+Specifies the level of (customer) support for this cluster.
 
 #### `collected_at` attribute
 
@@ -267,23 +272,24 @@ internally)
 ### Content of `cluster_thanos_info` table
 
 ```
-+--------------------------------------+---------------+--------------+-----------+---------------------+
-| cluster_id                           | ebs_account   | email_domain | managed   | collected_at        |
-|--------------------------------------+---------------+--------------+-----------+---------------------|
-| 00000000-0000-0000-0000-000000000000 | 1234567       | foo.bar.com  | False     | 2021-02-08 01:00:00 |
-| 11111111-1111-1111-1111-111111111111 | 2345678       | bar.cz       | False     | 2021-02-08 01:00:00 |
-| 22222222-2222-2222-2222-222222222222 | 3456789       | xyzzy.org    | True      | 2021-02-08 01:00:00 |
-| 33333333-3333-3333-3333-333333333333 | 4567890       | foo.bar.com  | False     | 2021-02-08 01:00:00 |
-| 44444444-4444-4444-4444-444444444444 | 5678901       | bar.cz       | False     | 2021-02-08 01:00:00 |
-| 55555555-5555-5555-5555-555555555555 | 6789012       | xyzzy.org    | False     | 2021-02-08 01:00:00 |
-+--------------------------------------+---------------+--------------+-----------+---------------------+
++--------------------------------------+---------------+-------------------+-----------+--------------+---------------------+
+| cluster_id                           |   ebs_account | email_domain      | managed   | support      | collected_at        |
+|--------------------------------------+---------------+-------------------+-----------+--------------+---------------------|
+| 12345678-ec5b-4552-9e2d-76c7bc4dee8f |    b'1234567' | us.ibm.com        | False     | None         | 2021-03-14 02:59:00 |
+| 12345678-ef92-4ee2-84c9-478f99b76fdb |    b'1234500' | customer1.com     | False     | Self-Support | 2021-03-14 02:59:00 |
+| 12345678-c145-4b12-850b-56a9de766d9c |    b'1234567' | us.ibm.com        | False     | None         | 2021-03-14 02:59:00 |
+| 12345678-6d6f-490d-a6e2-0e01fbbb962d |    b'1234600' | customer2.com     | False     | None         | 2021-03-14 02:59:00 |
+| 12345678-bde1-4e51-84e7-378030599471 |    b'1234700' | customer3.com     | False     | Premium      | 2021-03-14 02:59:00 |
+| 12345678-f0c3-4b44-80d2-ed6b5fc6c95f |    b'1234567' | us.ibm.com        | False     | Eval         | 2021-03-14 02:59:00 |
+| 12345678-8eb8-4d85-828d-ce940f1b9778 |    b'1234800' | us.ibm.com        | False     | Eval         | 2021-03-14 02:59:00 |
+| 12345678-8169-4a66-8c17-ce3a15eb81d3 |     b'123000' | customer4.co      | False     | Premium      | 2021-03-14 02:59:00 |
++--------------------------------------+---------------+-------------------+-----------+--------------+---------------------+
+
 ```
 
 ---
 **NOTE**
 
-`cluster_id` is mocked, these clusters are not real.
-`ebs_account` is mocked as well
-`email_domain` is mocked too
+`cluster_id`, `ebs_account`, `email_domain` are mocked.
 
 ---

--- a/docs/internal-pipeline/parquet_thanos.md
+++ b/docs/internal-pipeline/parquet_thanos.md
@@ -65,15 +65,18 @@ An example of UUID:
 * `_id` (string) - Cluster ID, contains UUID with cluster name
 * `email_domain` (string)
 * `managed` (bool)
+* `support` (string) - indicates level of paid cluster support
 
 An example:
 
 ```
-{_id="4976be4c-1111-460b-a4cf-e22ed1d96923", email_domain="us.ibm.com", managed="false"}
+{_id="4976be4c-1111-460b-a4cf-e22ed1d96923", email_domain="us.ibm.com", managed="false", support="Premium"}
 ```
 
 ---
 **NOTE**
+
+`support` is one of None, Eval, Standard, Premium, Self-Support.
 
 `_id/ClusterName` uses its canonical textual representation: the 16 octets of a
 UUID are represented as 32 hexadecimal (base-16) digits, displayed in five
@@ -104,12 +107,16 @@ Thanos will be decomissioned by DataHub team probably in Q2 2021, so any possibl
 `parquet-tools show cluster_thanos_info.parquet --head 4`
 
 ```
-+--------------------------------------+---------------+--------------------+-----------+---------------------+
-| cluster_id                           |   ebs_account | email_domain       | managed   | collected_at        |
-|--------------------------------------+---------------+--------------------+-----------+---------------------|
-| 07c82637-1111-46d4-b741-d2f8bb189050 |     b'123456' | bkfs.com           | False     | 2021-02-12 08:00:00 |
-| 2ef7ff7e-1111-41fd-8e67-763ba7ca68b5 |    b'1234565' | us.ibm.com         | False     | 2021-02-12 08:00:00 |
-| b603b714-1111-4210-a73d-47fa0d1fa2f5 |    b'1234565' | us.ibm.com         | False     | 2021-02-12 08:00:00 |
-| 35028b19-1111-422a-bc4c-ec164163b86e |    b'1234567' | redhat.com         | False     | 2021-02-12 08:00:00 |
-+--------------------------------------+---------------+--------------------+-----------+---------------------+
++--------------------------------------+---------------+-------------------+-----------+--------------+---------------------+
+| cluster_id                           |   ebs_account | email_domain      | managed   | support      | collected_at        |
+|--------------------------------------+---------------+-------------------+-----------+--------------+---------------------|
+| 12345678-ec5b-4552-9e2d-76c7bc4dee8f |    b'1234567' | us.ibm.com        | False     | None         | 2021-03-14 02:59:00 |
+| 12345678-ef92-4ee2-84c9-478f99b76fdb |    b'1234500' | customer1.com     | False     | Self-Support | 2021-03-14 02:59:00 |
+| 12345678-c145-4b12-850b-56a9de766d9c |    b'1234567' | us.ibm.com        | False     | None         | 2021-03-14 02:59:00 |
+| 12345678-6d6f-490d-a6e2-0e01fbbb962d |    b'1234600' | customer2.com     | False     | None         | 2021-03-14 02:59:00 |
+| 12345678-bde1-4e51-84e7-378030599471 |    b'1234700' | customer3.com     | False     | Premium      | 2021-03-14 02:59:00 |
+| 12345678-f0c3-4b44-80d2-ed6b5fc6c95f |    b'1234567' | us.ibm.com        | False     | Eval         | 2021-03-14 02:59:00 |
+| 12345678-8eb8-4d85-828d-ce940f1b9778 |    b'1234800' | us.ibm.com        | False     | Eval         | 2021-03-14 02:59:00 |
+| 12345678-8169-4a66-8c17-ce3a15eb81d3 |     b'123000' | customer4.co      | False     | Premium      | 2021-03-14 02:59:00 |
++--------------------------------------+---------------+-------------------+-----------+--------------+---------------------+
 ```

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 voluptuous
 parquet
 pytest
+python-snappy

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ pyparsing==2.4.7
     # via packaging
 pytest==6.2.2
     # via -r requirements.in
+python-snappy==0.6.0
+    # via -r requirements.in
 thriftpy2==0.4.14
     # via parquet
 toml==0.10.2

--- a/schemas/parquet_output_thanos_info.py
+++ b/schemas/parquet_output_thanos_info.py
@@ -30,6 +30,14 @@ from common import read_control_code, cli_arguments
 from common import validate_parquet_file
 from common import print_report
 
+# column with information regarding support type of cluster
+supportSchema = Schema(
+        Any(b"None",
+            b"Eval",
+            b"Standard",
+            b"Premium",
+            b"Self-Support",
+            ))
 
 # the whole schema for messages produced by Parquet factory into cluster_thanos_info.parquetfiles.
 schema = Schema({
@@ -38,6 +46,7 @@ schema = Schema({
         # Required("ebs_account"): Any(posIntInBytesValidator, b""), # TODO: check with authors
         Required("email_domain"): domainInBytesValidator,
         # Required("managed"): bytesTypeValidator,
+        Required("support"): supportSchema,
         Required("collected_at"): datetime.datetime,
         })
 

--- a/schemas/parquet_output_thanos_info_test.py
+++ b/schemas/parquet_output_thanos_info_test.py
@@ -42,6 +42,7 @@ attribute = (
         "cluster_id",
         "ebs_account",
         "email_domain",
+        "support",
         "collected_at"
         )
 
@@ -53,6 +54,7 @@ def correct_message():
             "cluster_id": b"123e4567-e89b-12d3-a456-426614174000",
             "ebs_account": b"123456",
             "email_domain": b"test.gov",
+            "support": b"Premium",
             "collected_at": datetime.now(),
         }
 

--- a/schemas/validators.py
+++ b/schemas/validators.py
@@ -538,7 +538,7 @@ def domainValidator(value):
     """Validate if value conformns to (e-mail) domain."""
     stringTypeValidator(value)
 
-    DOMAIN_RE = re.compile(r"((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}")
+    DOMAIN_RE = re.compile(r"((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,10}")
     if not DOMAIN_RE.fullmatch(value):
         raise Invalid("wrong e-mail domain:" + value)
 


### PR DESCRIPTION
I've tested it on the latest cluster_thanos_info generated in dev environment containing the support column. The schema now correctly reflects parquet-factory. 

I've also noticed we have some very long top level domain names in the `domain_name` attribute, the longest one having 10 characters (.consulting, valid domain, I checked), so I extended the regex.

Currently the only issues were missing `ebs_account`, but we (processing team) won't do anything with it as discussed with MartinB ([jira issue](https://issues.redhat.com/browse/CCXDEV-4086?focusedCommentId=15954230&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15954230)).

```
Status:
Processed messages: 17529

Valid messages:     17527
Invalid messages:   2     <---- only missing ebs, support is OK
Errors detected:    0
```