### PR TITLE
add new platforms detected in cluster_info.parquet (233/4916)

### DIFF
--- a/schemas/parquet_output_cluster_info.py
+++ b/schemas/parquet_output_cluster_info.py
@@ -41,7 +41,8 @@ platformSchema = Schema(
             b"None",
             b"Libvirt",
             b"oVirt",
-            b"GCP"))
+            b"GCP",
+            b"KubeVirt"))
 
 
 # the whole schema for messages produced by Parquet factory into cluster_info.parquet files."""


### PR DESCRIPTION
I was checking the parquet files for !188 and noticed there are new platforms started appearing in the cluster_info.parquet.

It affected 233/4916 records.

Added KubeVirt to enum