### PR TITLE
Alerts table

### DIFF
--- a/docs/internal-pipeline/parquet_output.md
+++ b/docs/internal-pipeline/parquet_output.md
@@ -213,7 +213,7 @@ Timestamp of report represented with millisecond precision, for example
 "2021-02-08 00:22:19" (this is the display format, the precision is higher
 internally)
 
-### Format of `operator_condition` table
+### Format of `failing_operator_conditions` table
 
 * `cluster_id` (byte array) cluster ID represented as UUID
 * `operator` (byte array) specifies which is the reporting operator
@@ -286,6 +286,101 @@ An example of path:
 ```
 archives/compressed/0a/0aaaaaaa-bbbb-cccc-dddd-ffffffffffff/202102/08/003201.tar.gz |
 ```
+
+
+
+
+
+### Format of `alerts` table
+
+* `cluster_id` (byte array) cluster ID represented as UUID
+* `name` (byte array) specifies the name of the reported alert
+* `state` (byte array) indicates the state of the alert (firing/pending/...)
+* `severity` (byte array) indicates the severeness of the alert
+* `labels` (byte array) JSON containing the alerts labels - necessary additional information
+* `archive_path` (byte array) path to the object stored in Ceph
+
+#### `cluster_id` attribute
+
+`cluster_id` uses its canonical textual representation: the 16 octets of a
+UUID are represented as 32 hexadecimal (base-16) digits, displayed in five
+groups separated by hyphens, in the form 8-4-4-4-12 for a total of 36
+characters (32 hexadecimal characters and 4 hyphens). For more information
+please look at
+[https://en.wikipedia.org/wiki/Universally_unique_identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier).
+
+An example of UUID:
+
+```
+3ba9b042-b8b8-4714-98e9-17915c2eeb95
+```
+
+#### `name` attribute
+
+Name of the alert being reported.
+
+Some examples of alerts:
+
+* `Watchdog`
+* `APIRemovedInNextReleaseInUse`
+* `KubePodCrashLooping`
+* `KubeAPIErrorBudgetBurn`
+* `ClusterOperatorDegraded`
+
+#### `state` attribute
+
+Indicates whether the alert is pending or firing.
+
+Examples:
+
+* `pending`
+* `firing`
+
+#### `severity` attribute
+
+Indicates how severe the alert is. Indicates the seriousness of the alert.
+
+Examples:
+
+* `warning`
+* `critical`
+* `alert`
+* `info`
+
+#### `labels` attribute
+
+A JSON encoded string/byte array containing necessary information for the alert about the cluster.
+
+Examples:
+
+* `{"prometheus":"openshift-monitoring/k8s","prometheus_replica":"prometheus-k8s-0"`
+* `{"group":"apiextensions.k8s.io","prometheus":"openshift-monitoring/k8s","prometheus_replica":"prometheus-k8s-0","resource":"customresourcedefinitions","version":"v1beta1"}`
+
+#### `archive_path` attribute
+
+This attribute contains path to object stored in Ceph. It must be real path
+with chunks splitted by slash character. The format of path is:
+
+```
+archives/compressed/{PREFIX}/{CLUSTER_ID}/{YEAR+MONTH}/{DAY}/{ID}.tar.gz |
+```
+
+An example of path:
+
+```
+archives/compressed/0a/0aaaaaaa-bbbb-cccc-dddd-ffffffffffff/202102/08/003201.tar.gz |
+```
+
+
+
+
+
+
+
+
+
+
+
 
 
 ## Possible enhancements
@@ -362,7 +457,7 @@ archives/compressed/0a/0aaaaaaa-bbbb-cccc-dddd-ffffffffffff/202102/08/003201.tar
 
 ---
 
-### Content of `operator_condition` table
+### Content of `failing_operator_conditions` table
 
 ```
 +--------------------------------------|----------------|------------------|--------------------|------------------------------------|----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------+
@@ -372,6 +467,28 @@ archives/compressed/0a/0aaaaaaa-bbbb-cccc-dddd-ffffffffffff/202102/08/003201.tar
 | 12345678-acc8-4439-9393-c12140c20033 | dns            | Progressing | True     | Reconciling                                       | At least 1 DNS DaemonSet is progressing.                                                    | archives/compressed/12/12345678-acc8-4439-9393-c12140c20033/202104/28/074816.tar.gz |
 | 12345678-acc8-4439-9393-c12140c20033 | kube-apiserver | Progressing | True     | NodeInstaller                                     | NodeInstallerProgressing: 3 nodes are at revision 47; 0 nodes have achieved new revision 55 | archives/compressed/12/12345678-acc8-4439-9393-c12140c20033/202104/28/074816.tar.gz |
 +--------------------------------------|----------------|-------------|----------|---------------------------------------------------|---------------------------------------------------------------------------------------------+
+```
+
+---
+**NOTE**
+
+`cluster_id` is mocked, these clusters are not real.
+
+---
+
+
+### Content of `alerts` table
+
+```
++--------------------------------------+---------------------------------+---------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
+| cluster_id                           | name                            | state   | severity   | labels                                                                                                                                                                      | archive_path                                                                        |
+|--------------------------------------+---------------------------------+---------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------|
+| a60d4af8-1234-418d-8fc0-bd1c73b97c6e | Watchdog                        | firing  | none       | {"prometheus":"openshift-monitoring/k8s","prometheus_replica":"prometheus-k8s-0"}                                                                                           | archives/compressed/a6/a60d4af8-1234-418d-8fc0-bd1c73b97c6e/202105/13/113513.tar.gz |
+| a60d4af8-1234-418d-8fc0-bd1c73b97c6e | APIRemovedInNextReleaseInUse    | pending | info       | {"group":"rbac.authorization.k8s.io","prometheus":"openshift-monitoring/k8s","prometheus_replica":"prometheus-k8s-0","resource":"roles","version":"v1beta1"}                | archives/compressed/a6/a60d4af8-1234-418d-8fc0-bd1c73b97c6e/202105/13/113513.tar.gz |
+| a60d4af8-1234-418d-8fc0-bd1c73b97c6e | APIRemovedInNextReleaseInUse    | pending | info       | {"group":"apiextensions.k8s.io","prometheus":"openshift-monitoring/k8s","prometheus_replica":"prometheus-k8s-0","resource":"customresourcedefinitions","version":"v1beta1"} | archives/compressed/a6/a60d4af8-1234-418d-8fc0-bd1c73b97c6e/202105/13/113513.tar.gz |
+| a60d4af8-1234-418d-8fc0-bd1c73b97c6e | APIRemovedInNextReleaseInUse    | pending | info       | {"group":"rbac.authorization.k8s.io","prometheus":"openshift-monitoring/k8s","prometheus_replica":"prometheus-k8s-0","resource":"rolebindings","version":"v1beta1"}         | archives/compressed/a6/a60d4af8-1234-418d-8fc0-bd1c73b97c6e/202105/13/113513.tar.gz |
+| a60d4af8-1234-418d-8fc0-bd1c73b97c6e | APIRemovedInNextEUSReleaseInUse | pending | info       | {"group":"apiextensions.k8s.io","prometheus":"openshift-monitoring/k8s","prometheus_replica":"prometheus-k8s-0","resource":"customresourcedefinitions","version":"v1beta1"} | archives/compressed/a6/a60d4af8-1234-418d-8fc0-bd1c73b97c6e/202105/13/113513.tar.gz |
++--------------------------------------+---------------------------------+---------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
 ```
 
 ---

--- a/schemas/parquet_output_alerts.py
+++ b/schemas/parquet_output_alerts.py
@@ -1,0 +1,66 @@
+"""Validator for messages produced by Parquet factory into alerts.parquet files."""
+
+import sys
+
+from voluptuous import Schema
+from voluptuous import Required, Optional
+from voluptuous import Any
+from voluptuous import ALLOW_EXTRA
+
+from validators import *
+
+from common import read_control_code, cli_arguments
+from common import validate_parquet_file
+from common import print_report
+
+
+# column with information about the state of alert
+stateSchema = Schema(
+    Any(
+        b"pending",
+        b"firing"
+    )
+)
+
+# column with information about the severity of the alert
+# yes, "" and "none" are real valid values .....
+severitySchema = Schema(
+    Any(
+        b"",
+        b"none",
+        b"page",
+        b"warning",
+        b"critical",
+        b"high",
+        b"info",
+        b"alert"
+    )
+)
+
+# the whole schema for messages produced by Parquet factory into cluster_info.parquet files."""
+schema = Schema({
+        Required("cluster_id"): uuidInBytesValidator,
+        Required("name"): notEmptyBytesTypeValidator,
+        Required("state"): stateSchema,
+        Required("severity"): severitySchema,
+        Required("labels"): jsonInBytesValidator,
+        Required("archive_path"): pathToCephInBytesValidator,
+        })
+
+
+def main():
+    """Entry point to this script."""
+    # Parse all CLI arguments.
+    args = cli_arguments()
+    verbose = args.verbose
+    input_file = args.input
+
+    # validate the provided Parquet file
+    report = validate_parquet_file(schema, input_file, verbose)
+
+    # print report from schema validation
+    print_report(report, args.nocolors)
+
+
+if __name__ == "__main__":
+    main()

--- a/schemas/parquet_output_alerts.py
+++ b/schemas/parquet_output_alerts.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Validator for messages produced by Parquet factory into alerts.parquet files."""
 
 import sys

--- a/schemas/parquet_output_alerts_test.py
+++ b/schemas/parquet_output_alerts_test.py
@@ -1,0 +1,114 @@
+"""Unit tests for ccx_ocp_results module."""
+
+import pytest
+import sys
+
+from voluptuous import Invalid
+
+from parquet_output_alerts import schema, main
+from common import validate
+
+
+@pytest.fixture
+def validation_schema():
+    """Provide standard schema to check messages."""
+    return schema
+
+
+# verbosity level
+verbose = (True, False)
+
+# attributes to check
+attribute = (
+    "cluster_id",
+    "name",
+    "state",
+    "severity",
+    "labels",
+    "archive_path"
+)
+
+@pytest.fixture
+def correct_message():
+    """Provide correct message to be tested."""
+    return {
+        "cluster_id": b"123e4567-e89b-12d3-a456-426614174000",
+        "name": b"Watchdog",
+        "state": b"firing",
+        "severity": b"critical",
+        "labels": b"{\"prometheus\":\"openshift-monitoring/k8s\",\"prometheus_replica\":\"prometheus-k8s-0\"}",
+        "archive_path": b"archives/compressed/00/00000000-0000-0000-0000-000000000000/202102/08/002219.tar.gz"
+    }
+
+
+def test_main_help():
+    """Test the main function when -h parameter is given."""
+    sys.argv.append("-h")
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 0
+
+
+def test_main_input():
+    """Test the main function when -i parameter is given."""
+    sys.argv.append("-i test")
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 0
+
+
+@pytest.mark.parametrize("verbose", verbose)
+def test_validate_no_payload(validation_schema, verbose):
+    """Test the validation for improper (no) payload."""
+    # it should fail
+    with pytest.raises(ValueError) as excinfo:
+        validate(schema, None, verbose)
+
+
+@pytest.mark.parametrize("verbose", verbose)
+def test_validate_correct_message(validation_schema, verbose, correct_message):
+    """Test the validation for proper message."""
+    # it should not fail
+    validate(schema, correct_message, verbose)
+
+@pytest.mark.parametrize("verbose", verbose)
+def test_validate_message_without_cluster_id_attribute(validation_schema, verbose, correct_message):
+    """Test the validation for improper payload."""
+    del correct_message["cluster_id"]
+    # it should fail
+    with pytest.raises(Invalid) as excinfo:
+        validate(schema, correct_message, verbose)
+
+
+@pytest.mark.parametrize("attribute", attribute)
+@pytest.mark.parametrize("verbose", verbose)
+def test_validate_message_without_attributes(validation_schema, verbose, correct_message,
+                                             attribute):
+    """Test the validation for improper payload."""
+    del correct_message[attribute]
+    # it should fail
+    with pytest.raises(Invalid) as excinfo:
+        validate(schema, correct_message, verbose)
+
+
+@pytest.mark.parametrize("attribute", attribute)
+@pytest.mark.parametrize("verbose", verbose)
+def test_validate_message_wrong_attributes(validation_schema, verbose, correct_message, attribute):
+    """Test the validation for improper payload."""
+
+    # check with number
+    correct_message[attribute] = 0
+    # it should fail
+    with pytest.raises(Invalid) as excinfo:
+        validate(schema, correct_message, verbose)
+
+    # check with different data type
+    correct_message[attribute] = None
+    # it should fail
+    with pytest.raises(Invalid) as excinfo:
+        validate(schema, correct_message, verbose)
+
+    correct_message[attribute] = False
+    # it should fail
+    with pytest.raises(Invalid) as excinfo:
+        validate(schema, correct_message, verbose)

--- a/schemas/parquet_output_alerts_test.py
+++ b/schemas/parquet_output_alerts_test.py
@@ -42,6 +42,7 @@ attribute = (
     "archive_path"
 )
 
+
 @pytest.fixture
 def correct_message():
     """Provide correct message to be tested."""
@@ -50,8 +51,10 @@ def correct_message():
         "name": b"Watchdog",
         "state": b"firing",
         "severity": b"critical",
-        "labels": b"{\"prometheus\":\"openshift-monitoring/k8s\",\"prometheus_replica\":\"prometheus-k8s-0\"}",
-        "archive_path": b"archives/compressed/00/00000000-0000-0000-0000-000000000000/202102/08/002219.tar.gz"
+        "labels":
+        b"{\"prometheus\":\"openshift-monitoring/k8s\",\"prometheus_replica\":\"prometheus-0\"}",
+        "archive_path":
+        b"archives/compressed/00/00000000-0000-0000-0000-000000000000/202102/08/002219.tar.gz"
     }
 
 
@@ -85,6 +88,7 @@ def test_validate_correct_message(validation_schema, verbose, correct_message):
     # it should not fail
     validate(schema, correct_message, verbose)
 
+
 @pytest.mark.parametrize("verbose", verbose)
 def test_validate_message_without_cluster_id_attribute(validation_schema, verbose, correct_message):
     """Test the validation for improper payload."""
@@ -107,7 +111,8 @@ def test_validate_message_without_attributes(validation_schema, verbose, correct
 
 @pytest.mark.parametrize("attribute", attribute)
 @pytest.mark.parametrize("verbose", verbose)
-def test_validate_message_wrong_attributes(validation_schema, verbose, correct_message, attribute):
+def test_validate_message_wrong_attributes(validation_schema, verbose, correct_message,
+                                           attribute):
     """Test the validation for improper payload."""
 
     # check with number

--- a/schemas/parquet_output_alerts_test.py
+++ b/schemas/parquet_output_alerts_test.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for ccx_ocp_results module."""
 
 import pytest

--- a/schemas/validators.py
+++ b/schemas/validators.py
@@ -793,3 +793,16 @@ def pathToCephInBytesValidator(value):
     value = value.decode("utf-8")
 
     pathToCephValidator(value)
+
+
+def jsonInBytesValidator(value):
+    """Validate if the value is JSON stored in string."""
+    # input must be a byte array
+    bytesTypeValidator(value)
+
+    value = value.decode("utf-8")
+
+    # try to parse into JSON
+    decoded = json.loads(value)
+
+    assert decoded is not None


### PR DESCRIPTION
Adds schema and validator for `alerts` table generated by parquet-factory.
Also renamed `operator_condition` to `failing_operator_conditions`

Tested `make tests` + validate an alerts.parquet generated on DEV environment:
```
Status:
Processed messages: 35241

Valid messages:     35241
Invalid messages:   0
Errors detected:    0
```