### PR TITLE
Remove condition field from error key doc

### DIFF
--- a/docs/external-pipeline/content_service.md
+++ b/docs/external-pipeline/content_service.md
@@ -74,7 +74,6 @@ type RuleErrorKeyContent struct {
 // ErrorKeyMetadata is a Go representation of the `metadata.yaml`
 // file inside of an error key content directory.
 type ErrorKeyMetadata struct {
-	Condition   string   `yaml:"condition" json:"condition"`
 	Description string   `yaml:"description" json:"description"`
 	Impact      string   `yaml:"impact" json:"impact"`
 	Likelihood  int      `yaml:"likelihood" json:"likelihood"`


### PR DESCRIPTION
Condition field has been deprecated and is not being parsed anymore. See https://github.com/RedHatInsights/insights-content-service/pull/256, https://github.com/RedHatInsights/insights-operator-utils/pull/173 and https://github.com/RedHatInsights/insights-results-aggregator-data/pull/145