### PR TITLE
Removed Python 3.6 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
   - "3.8-dev"  # 3.8 development branch


### PR DESCRIPTION
Removed Python 3.6 from CI

It is no longer supported:
https://en.wikipedia.org/wiki/History_of_Python#Support